### PR TITLE
Access the bundled args passed to the the transform fn using “args” k…

### DIFF
--- a/src/utils/evalUtils.js
+++ b/src/utils/evalUtils.js
@@ -45,7 +45,7 @@ function safeEval(functionBody, args) {
      * TODO generate the fn only once upon receiving the generator, store
      *  the generated func as part of the generator config in the config
      */
-    const func = notevil.Function('ctx', functionBody);
+    const func = notevil.Function('args', functionBody);
     debug(`evalUtils.safeEval generated function: ${func}`);
     debug(`evalUtils.safeEval calling function with args: ${args}`);
     const retval = func(args);

--- a/test/utils/evalUtils.js
+++ b/test/utils/evalUtils.js
@@ -310,7 +310,7 @@ describe('test/utils/evalUtils >', (done) => {
         n: -5,
       };
       const str = `
-        return [ctx.abc, ctx.n, ctx.abc.slice(ctx.n)];
+        return [args.abc, args.n, args.abc.slice(args.n)];
       `;
       const res = eu.safeEval(str, ctx);
       expect(res).to.be.array;


### PR DESCRIPTION
…eyword (instead of “ctx)

(since the bundled args is expected to have a attribute named “ctx”)