### PR TITLE
Add activity logging after successful transform function

### DIFF
--- a/src/remoteCollection/handleCollectResponse.js
+++ b/src/remoteCollection/handleCollectResponse.js
@@ -69,9 +69,10 @@ function handleCollectResponse(collectResponse) {
           'handleCollectResponse should have a "name" attribute');
       }
 
-      logger.info(
-        `Generator=${collectRes.name},numSamples=${transformedSamples.length}`
-      );
+      logger.info(`{
+        generator: ${collectRes.name},
+        numSamples: ${transformedSamples.length},
+      }`);
 
       enqueue(transformedSamples);
     } catch (err) {

--- a/test/remoteCollection/handleCollectResponse.js
+++ b/test/remoteCollection/handleCollectResponse.js
@@ -150,9 +150,8 @@ describe('test/remoteCollection/handleCollectResponse.js >', () => {
     .then(() => {
       // check the logs
       expect(winston.info.calledTwice).to.be.true;
-      expect(winston.info.args[0][0]).to.be.equal(
-        'Generator=mockGenerator,numSamples=2'
-      );
+      expect(winston.info.args[0][0]).contains('generator: mockGenerator');
+      expect(winston.info.args[0][0]).contains('numSamples: 2');
       expect(sampleQueueOps.sampleQueue.length).to.be.equal(2);
       expect(sampleQueueOps.sampleQueue[0])
       .to.eql({ name: 'S1|A1', value: 10 });


### PR DESCRIPTION
Log line must include the number of samples returned and the sample generator name.