### PR TITLE
Utility fn to apply generator template contextDefinition defaults to …

### DIFF
--- a/src/heartbeat/utils.js
+++ b/src/heartbeat/utils.js
@@ -34,6 +34,29 @@ function updateCollectorConfig(res) {
 } // updateCollectorConfig
 
 /**
+ * Assign any default values from the template into the generator context if
+ * no value was already provided in the generator context.
+ *
+ * @param {Object} ctx - The context from the generator
+ * @param {Object} def - The contextDefinition from the generator template
+ * @returns {Object} the context object with default values populated
+ */
+function assignContextDefaults(ctx, def) {
+  if (!ctx) {
+    ctx = {};
+  }
+
+  Object.keys(def).forEach((key) => {
+    if (!ctx.hasOwnProperty(key) && def[key].hasOwnProperty('default')) {
+      ctx[key] = def[key].default;
+    }
+  });
+
+  debug('assignContextDefaults returning', ctx);
+  return ctx;
+} // assignContextDefaults
+
+/**
  * Function to setup a generator repeater and add the generator to the
  * collector config
  * @param {Object} res - Heartbeat Response
@@ -108,6 +131,7 @@ function updateGenerator(res) {
 
 module.exports = {
   addGenerator,
+  assignContextDefaults, // exporting for testing purposes only
   deleteGenerator,
   updateGenerator,
   updateCollectorConfig,

--- a/test/heartbeat/utils.js
+++ b/test/heartbeat/utils.js
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2017, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * test/heartbeat/utils.js
+ */
+'use strict';
+
+const expect = require('chai').expect;
+const hu = require('../../src/heartbeat/utils');
+
+describe('test/heartbeat/utils.js >', () => {
+  describe('assignContextDefaults >', () => {
+    it('null ctx OK', () => {
+      const ctx = null;
+      const def = { a: { default: 'abc' } };
+      expect(hu.assignContextDefaults(ctx, def)).to.have.property('a', 'abc');
+    });
+
+    it('empty ctx OK', () => {
+      const ctx = {};
+      const def = { a: { default: 'abc' } };
+      expect(hu.assignContextDefaults(ctx, def)).to.have.property('a', 'abc');
+    });
+
+    it('undefined ctx OK', () => {
+      const ctx = undefined;
+      const def = { a: { default: 'abc' } };
+      expect(hu.assignContextDefaults(ctx, def)).to.have.property('a', 'abc');
+    });
+
+    it('def with default does not overwrite ctx if exists', () => {
+      const ctx = { a: 'xxx' };
+      const def = { a: { default: 'abc' } };
+      expect(hu.assignContextDefaults(ctx, def)).to.have.property('a', 'xxx');
+    });
+
+    it('def with no default has no effect', () => {
+      const ctx = { a: 'xxx' };
+      const def = { a: { description: 'This is "a"' } };
+      expect(hu.assignContextDefaults(ctx, def)).to.have.property('a', 'xxx');
+    });
+
+    it('def with empty default adds attribute to ctx', () => {
+      const ctx = { };
+      const def = { a: { default: '' } };
+      expect(hu.assignContextDefaults(ctx, def)).to.have.property('a', '');
+    });
+
+    it('def with null default adds attribute to ctx', () => {
+      const ctx = { };
+      const def = { a: { default: null } };
+      expect(hu.assignContextDefaults(ctx, def)).to.have.property('a', null);
+    });
+  });
+});


### PR DESCRIPTION
…generator context


Note: this PR does not update the heartbeat listener to *use* this new fn... that will be a separate PR.