### PR TITLE
add clear config to tests that use config

### DIFF
--- a/test/commands/start.js
+++ b/test/commands/start.js
@@ -163,6 +163,8 @@ describe('test/commands/start >', () => {
   });
 
   describe('execute directly >', () => {
+    after(() => configModule.clearConfig());
+
     it('ok, no proxy', (done) => {
       start.execute(collectorName, refocusUrl, accessToken, {})
       .then(() => {

--- a/test/heartbeat/utils.js
+++ b/test/heartbeat/utils.js
@@ -180,6 +180,8 @@ describe('test/heartbeat/utils.js >', () => {
       repeater.stop(genName2);
     });
 
+    after(() => configModule.clearConfig());
+
     it('different queues are created for different generators', (done) => {
       const heartbeatResp = {
         collectorConfig: {

--- a/test/remoteCollection/handleCollectResponse.js
+++ b/test/remoteCollection/handleCollectResponse.js
@@ -251,6 +251,7 @@ describe('test/remoteCollection/handleCollectResponse.js >', () => {
     after(() => {
       // restore winston stub
       winstonInfoStub.restore();
+      configModule.clearConfig();
     });
 
     const collectRes = {

--- a/test/utils/httpUtils.js
+++ b/test/utils/httpUtils.js
@@ -28,7 +28,6 @@ describe('test/utils/httpUtils.js >', () => {
   const properRegistryObject = { url: dummyStr, token: dummyToken };
   const sampleArr = [{ name: 'sample1' }, { name: 'sample2' }];
   configModule.clearConfig();
-  configModule.initializeConfig();
 
   describe('doBulkUpsert >', () => {
     const dummyUserToken = 'some-user-token-string-asfdfhsdjf';
@@ -36,10 +35,13 @@ describe('test/utils/httpUtils.js >', () => {
     // clear stub
     after(mock.clearRoutes);
 
-    before(() => {
+    beforeEach(() => {
+      configModule.initializeConfig();
       const config = configModule.getConfig();
       config.refocus.collectorToken = dummyToken;
     });
+
+    after(() => configModule.clearConfig());
 
     it('no url in refocus instance object, gives validation error', (done) => {
       httpUtils.doBulkUpsert([], dummyUserToken)


### PR DESCRIPTION
- hopefully this will decrease the number of flappers. Flappers being the tests that depend on config 
- the flappers are so bad, that duplicating a test (ie. test/remoteCollection/collect.js) causes 17 test failures across different files