### PR TITLE
Remove hard-coded generator interval...

### DIFF
--- a/src/heartbeat/utils.js
+++ b/src/heartbeat/utils.js
@@ -195,9 +195,6 @@ function addGenerators(res) {
       g.refocus = { url: cr.url };
       if (cr.proxy) g.refocus.proxy = cr.proxy;
 
-      // TODO remove me once generator returns interval
-      if (!g.interval) g.interval = 55000;
-
       config.generators[g.name] = g;
 
       // queue name same as generator name
@@ -256,9 +253,6 @@ function updateGenerators(res) {
       // Add Refocus url/proxy to generator
       g.refocus = { url: cr.url };
       if (cr.proxy) g.refocus.proxy = cr.proxy;
-
-      // TODO remove me once generator returns interval
-      if (!g.interval) g.interval = 55000;
 
       Object.keys(g).forEach((key) => config.generators[g.name][key] = g[key]);
 

--- a/src/repeater/repeater.js
+++ b/src/repeater/repeater.js
@@ -252,7 +252,7 @@ function create(def) {
 function createGeneratorRepeater(generator, func, onProgress) {
   return create({
     name: generator.name,
-    interval: generator.interval,
+    interval: 1000 * generator.intervalSecs, // convert to millis
     func: () => func(generator),
     onProgress,
     bulk: u.isBulk(generator),

--- a/test/commands/deregister.js
+++ b/test/commands/deregister.js
@@ -12,7 +12,7 @@
 'use strict'; // eslint-disable-line strict
 const expect = require('chai').expect;
 
-describe('test/commands/deregister >', () => {
+describe('test/commands/deregister.js >', () => {
   // TODO: child process fails on travis with error
   // /bin/sh: 1: refocus-collector: not found
   it('logs the expected result', (done) => {

--- a/test/commands/pause.js
+++ b/test/commands/pause.js
@@ -14,7 +14,7 @@ const expect = require('chai').expect;
 const fork = require('child_process').fork;
 const constants = require('./constants');
 
-describe('test/commands/pause >', () => {
+describe('test/commands/pause.js >', () => {
   const collectorName = 'collector1';
   const refocusUrl = 'http://www.refocus-pause-test.com';
   const accessToken = 'abcdefghijklmnopqrstuvwxyz';

--- a/test/commands/reregister.js
+++ b/test/commands/reregister.js
@@ -14,7 +14,7 @@ const expect = require('chai').expect;
 const fork = require('child_process').fork;
 const constants = require('./constants');
 
-describe('test/commands/reregister >', () => {
+describe('test/commands/reregister.js >', () => {
   const collectorName = 'collector1';
   const refocusUrl = 'http://www.example.com';
   const accessToken = 'abcdefghijklmnopqrstuvwxyz';

--- a/test/commands/resume.js
+++ b/test/commands/resume.js
@@ -14,7 +14,7 @@ const expect = require('chai').expect;
 const fork = require('child_process').fork;
 const constants = require('./constants');
 
-describe('test/commands/resume >', () => {
+describe('test/commands/resume.js >', () => {
   const collectorName = 'collector1';
   const refocusUrl = 'http://www.refocus-resume-test.com';
   const accessToken = 'abcdefghijklmnopqrstuvwxyz';

--- a/test/commands/start.js
+++ b/test/commands/start.js
@@ -24,7 +24,7 @@ const sgt = require('../sgt');
 require('superagent-proxy')(request);
 const constants = require('./constants');
 
-describe('test/commands/start >', () => {
+describe('test/commands/start.js >', () => {
   const collectorName = 'collector1';
   const refocusUrl = 'http://www.example.com';
   const accessToken = 'abcdefghijklmnopqrstuvwxyz';
@@ -190,6 +190,7 @@ describe('test/commands/start >', () => {
             token: 'some-dummy-token-gen1',
             generatorTemplate: sgt,
             aspects: [{ name: 'foo' }],
+            intervalSecs: 5,
             subjectQuery: '?absolutePath=Canada',
           },
           {
@@ -197,6 +198,7 @@ describe('test/commands/start >', () => {
             token: 'some-dummy-token-gen2',
             generatorTemplate: sgt,
             aspects: [{ name: 'bar' }],
+            intervalSecs: 3,
             subjectQuery: '?absolutePath=Canada',
           },
         ],

--- a/test/commands/status.js
+++ b/test/commands/status.js
@@ -12,7 +12,7 @@
 'use strict'; // eslint-disable-line strict
 const expect = require('chai').expect;
 
-describe('test/commands/status >', () => {
+describe('test/commands/status.js >', () => {
   // TODO: child process fails on travis with error
   // /bin/sh: 1: refocus-collector: not found
   it('logs the expected result', (done) => {

--- a/test/commands/stop.js
+++ b/test/commands/stop.js
@@ -14,7 +14,7 @@ const expect = require('chai').expect;
 const fork = require('child_process').fork;
 const constants = require('./constants');
 
-describe('test/commands/stop >', () => {
+describe('test/commands/stop.js >', () => {
   const collectorName = 'collector1';
   const refocusUrl = 'http://www.refocus-stop-test.com';
   const accessToken = 'abcdefghijklmnopqrstuvwxyz';

--- a/test/commands/utils.js
+++ b/test/commands/utils.js
@@ -14,7 +14,7 @@ const expect = require('chai').expect;
 const configModule = require('../../src/config/config');
 const cmdUtils = require('../../src/commands/utils');
 
-describe('test/commands/utils >', () => {
+describe('test/commands/utils.js >', () => {
   describe('validateArgs >', () => {
     it('ok, valid args', (done) => {
       const args = {

--- a/test/heartbeat/heartbeat.js
+++ b/test/heartbeat/heartbeat.js
@@ -37,7 +37,7 @@ const generator1 = {
     url: refocusUrl,
   },
   token: 'mygeneratorusertoken',
-  interval: 6000,
+  intervalSecs: 6,
 };
 
 const generator1Updated = {
@@ -52,12 +52,12 @@ const generator1Updated = {
     url: refocusUrl,
   },
   token: 'mygeneratorusertoken',
-  interval: 12000,
+  intervalSecs: 12,
 };
 
 const generator2 = {
   name: 'generator2_heartbeat',
-  interval: 6000,
+  intervalSecs: 6,
   aspects: [{ name: 'A2' }],
   subjectQuery: '?absolutePath=S1.S2',
   subjects: [{ absolutePath: 'S1.S2', name: 'S2' }],
@@ -75,7 +75,7 @@ const generator2 = {
 
 const generator3 = {
   name: 'generator3_heartbeat',
-  interval: 6000,
+  intervalSecs: 6,
   aspects: [{ name: 'A3' }],
   subjectQuery: '?absolutePath=S1.S2',
   subjects: [{ absolutePath: 'S1.S2', name: 'S2' }],

--- a/test/heartbeat/listener.js
+++ b/test/heartbeat/listener.js
@@ -54,7 +54,7 @@ describe('test/heartbeat/listener.js >', () => {
         collectors: [{ name: 'agent1' }],
         generatorTemplate: sgt,
         token: 'asd123asd',
-        interval: 6000,
+        intervalSecs: 6,
       },
     ],
     generatorsUpdated: [],
@@ -94,7 +94,7 @@ describe('test/heartbeat/listener.js >', () => {
           subjectQuery: 'absolutePath=Parent.Child.*&tags=Primary',
           context: { baseTrustUrl: 'https://example.api' },
           collectors: [{ name: 'agent1' }],
-          interval: 6000,
+          intervalSecs: 6,
           token: 'asd123asd',
         },
       ],
@@ -121,7 +121,7 @@ describe('test/heartbeat/listener.js >', () => {
           subjectQuery: 'absolutePath=Parent.Child.*&tags=Primary',
           context: { baseTrustUrl: 'https://example.api', },
           collectors: [{ name: 'agent1' }],
-          interval: 6000,
+          intervalSecs: 6,
           token: 'asd123asd',
         },
       ],
@@ -130,7 +130,7 @@ describe('test/heartbeat/listener.js >', () => {
     hbResponse.generatorsUpdated = [
       {
         name: 'Core_Trust3',
-        interval: 1000,
+        intervalSecs: 1,
         context: { baseTrustUrl: 'https://example.api', },
         generatorTemplate: sgt,
         subjectQuery: 'absolutePath=Parent.Child.*&tags=Primary',
@@ -162,7 +162,7 @@ describe('test/heartbeat/listener.js >', () => {
           subjectQuery: 'absolutePath=Parent.Child.*&tags=Primary',
           context: { baseTrustUrl: 'https://example.api', },
           collectors: [{ name: 'agent1' }],
-          interval: 6000,
+          intervalSecs: 6,
           token: 'asd123asd',
         },
       ],
@@ -191,7 +191,7 @@ describe('test/heartbeat/listener.js >', () => {
           subjectQuery: 'absolutePath=Parent.Child.*&tags=Primary',
           context: { baseTrustUrl: 'https://example.api', },
           collectors: [{ name: 'agent1' }],
-          interval: 6000,
+          intervalSecs: 6,
           token: 'asd123asd',
         },
       ],
@@ -216,7 +216,7 @@ describe('test/heartbeat/listener.js >', () => {
           subjects: [{ absolutePath: 'NA1' }, { absolutePath: 'NA2' }],
           context: { baseTrustUrl: 'https://example.api', },
           collectors: [{ name: 'agent1' }],
-          interval: 6000,
+          intervalSecs: 6,
           token: 'asd123asd',
         },
       ],
@@ -247,7 +247,7 @@ describe('test/heartbeat/listener.js >', () => {
           subjects: [{ absolutePath: 'NA1' }, { absolutePath: 'NA2' }],
           context: { baseTrustUrl: 'https://example.api', },
           collectors: [{ name: 'agent1' }],
-          interval: 6000,
+          intervalSecs: 6,
           token: 'asd123asd',
         },
       ],
@@ -272,7 +272,7 @@ describe('test/heartbeat/listener.js >', () => {
           context: { baseTrustUrl: 'https://example.api', },
           subjects: [{ absolutePath: 'NA4' }, { absolutePath: 'NA2' }],
           collectors: [{ name: 'agent1' }],
-          interval: 6000,
+          intervalSecs: 6,
           token: 'asd123asd',
         },
       ],
@@ -296,7 +296,7 @@ describe('test/heartbeat/listener.js >', () => {
         {
           name: 'ABC_DATA',
           aspects: [{ name: 'A' }],
-          interval: 6000,
+          intervalSecs: 6,
           generatorTemplateName: 'refocus-trust1-collector',
           generatorTemplate: sgt,
           subjectQuery: 'absolutePath=Parent.Child.*&tags=Primary',
@@ -306,7 +306,7 @@ describe('test/heartbeat/listener.js >', () => {
         {
           name: 'Fghijkl_Mnopq',
           aspects: [{ name: 'A' }],
-          interval: 1000,
+          intervalSecs: 1,
           context: { baseTrustUrl: 'https://fghijkl.data.mnopq.com', },
           generatorTemplate: sgt,
           subjectQuery: 'absolutePath=Parent.Child.*&tags=Primary',
@@ -346,7 +346,7 @@ describe('test/heartbeat/listener.js >', () => {
       generatorsAdded: {
         name: 'Fghijkl_Mnopq',
         aspects: [{ name: 'A' }],
-        interval: 1000,
+        intervalSecs: 1,
         context: { baseTrustUrl: 'https://example.api', },
       },
       generatorsDeleted: {
@@ -355,7 +355,7 @@ describe('test/heartbeat/listener.js >', () => {
       generatorsUpdated: {
         name: 'Fghijkl_Mnopq',
         aspects: [{ name: 'A' }],
-        interval: 1000,
+        intervalSecs: 1,
         context: { baseTrustUrl: 'https://example.api', },
       },
     };
@@ -364,7 +364,7 @@ describe('test/heartbeat/listener.js >', () => {
     done();
   });
 
-  describe('with encrypted context attributes', () => {
+  describe('with encrypted context attributes >', () => {
     const password = 'reallylongsecretpassword';
     const token = 'alphanumerictoken';
     const secret = 'collectortoken' + hbResponse.timestamp;
@@ -394,7 +394,7 @@ describe('test/heartbeat/listener.js >', () => {
               token: encrypt(token, secret, encryptionAlgorithm),
             },
             collectors: [{ name: 'agent1' }],
-            interval: 6000,
+            intervalSecs: 6000,
             token: 'asd123asd',
           },
         ],
@@ -451,7 +451,7 @@ describe('test/heartbeat/listener.js >', () => {
               token: encrypt(token, secret, encryptionAlgorithm),
             },
             collectors: [{ name: 'agent1' }],
-            interval: 6000,
+            intervalSecs: 6000,
             token: 'asd123asd',
           },
         ],
@@ -488,7 +488,7 @@ describe('test/heartbeat/listener.js >', () => {
             token: encrypt(newToken, secret, encryptionAlgorithm),
           },
           collectors: [{ name: 'agent2' }],
-          interval: 6000,
+          intervalSecs: 6,
           token: 'asd123asd',
         },
       ];
@@ -539,7 +539,7 @@ describe('test/heartbeat/listener.js >', () => {
               token: encrypt(token, secret, encryptionAlgorithm),
             },
             collectors: [{ name: 'agent1' }],
-            interval: 6000,
+            intervalSecs: 6,
             token: 'asd123asd',
           },
         ],
@@ -576,7 +576,7 @@ describe('test/heartbeat/listener.js >', () => {
             token: encrypt(newToken, secret, encryptionAlgorithm),
           },
           collectors: [{ name: 'agent2' }],
-          interval: 6000,
+          intervalSecs: 6,
           token: 'asd123asd',
         },
       ];

--- a/test/heartbeat/utils.js
+++ b/test/heartbeat/utils.js
@@ -280,6 +280,7 @@ describe('test/heartbeat/utils.js >', () => {
                 bulk: true,
               },
             },
+            intervalSecs: 2,
             subjectQuery: '?absolutePath=Canada',
           },
           {
@@ -292,6 +293,7 @@ describe('test/heartbeat/utils.js >', () => {
                 bulk: true,
               },
             },
+            intervalSecs: 3,
             subjectQuery: '?absolutePath=Canada',
           },
         ],

--- a/test/remoteCollection/collect.js
+++ b/test/remoteCollection/collect.js
@@ -30,7 +30,7 @@ describe('test/remoteCollection/collect.js >', () => {
       const remoteUrl = 'http://bart.gov.api/';
       const generator = {
         name: 'Generator0',
-        interval: 600,
+        intervalSecs: 1,
         context: {},
         generatorTemplate: {
           connection: {
@@ -79,7 +79,7 @@ describe('test/remoteCollection/collect.js >', () => {
       const remoteUrl = 'http://www.xyz.com/';
       const generator = {
         name: 'Generator0',
-        interval: 600,
+        intervalSecs: 1,
         context: {},
         generatorTemplate: {
           connection: {
@@ -163,7 +163,7 @@ describe('test/remoteCollection/collect.js >', () => {
       const remoteUrl1 = 'http://randonUnAvailableUrl.false/';
       const generator = {
         name: 'Generator0',
-        interval: 600,
+        intervalSecs: 1,
         context: {},
         generatorTemplate: {
           connection: {
@@ -195,7 +195,7 @@ describe('test/remoteCollection/collect.js >', () => {
       'the "res" attribute', (done) => {
       const generator = {
         name: 'Generator0',
-        interval: 600,
+        intervalSecs: 1,
         context: {},
         generatorTemplate: {
           connection: {
@@ -220,7 +220,7 @@ describe('test/remoteCollection/collect.js >', () => {
       const remoteUrl = 'http://www.xyz.com/';
       const generator = {
         name: 'Generator0',
-        interval: 600,
+        intervalSecs: 1,
         context: {},
         generatorTemplate: {
           connection: {
@@ -255,7 +255,7 @@ describe('test/remoteCollection/collect.js >', () => {
       const remoteUrl = 'http://www.xyz.com/';
       const generator = {
         name: 'Generator0',
-        interval: 600,
+        intervalSecs: 1,
         context: {},
         generatorTemplate: {
           connection: {

--- a/test/repeater/repeater.js
+++ b/test/repeater/repeater.js
@@ -14,6 +14,7 @@ const tracker = repeater.tracker;
 const expect = require('chai').expect;
 const ref = { url: 'mock.refocus.com' };
 const logger = require('winston');
+const MILLIS = 1000;
 logger.configure({ level: 0 });
 
 describe('test/repeater/repeater.js >', () => {
@@ -26,7 +27,7 @@ describe('test/repeater/repeater.js >', () => {
     it('should start a new generator repeat', (done) => {
       const def = {
         name: 'Generator0',
-        interval: 600,
+        intervalSecs: 1,
         context: {},
         generatorTemplate: {
           connection: {
@@ -44,7 +45,7 @@ describe('test/repeater/repeater.js >', () => {
       const ret = repeater.createGeneratorRepeater(def, dummyFunc,
         dummyOnProgress);
       expect(ret.handle).to.not.equal(undefined);
-      expect(ret.interval).to.equal(def.interval);
+      expect(ret.interval).to.equal(MILLIS * def.intervalSecs);
       expect(ret.name).to.equal('Generator0');
       expect(ret.funcName).to.equal('func');
       expect(tracker.Generator0._bulk).to.equal(ret.handle);
@@ -54,7 +55,7 @@ describe('test/repeater/repeater.js >', () => {
     it('should set onProgress callback to handleCollectResponse', (done) => {
       const def = {
         name: 'Generator0.1',
-        interval: 6000,
+        intervalSecs: 6,
         context: {},
         generatorTemplate: {
           connection: {
@@ -72,7 +73,7 @@ describe('test/repeater/repeater.js >', () => {
       const ret = repeater.createGeneratorRepeater(def, dummyFunc,
         dummyOnProgress);
       expect(ret.handle).to.not.equal(undefined);
-      expect(ret.interval).to.equal(def.interval);
+      expect(ret.interval).to.equal(MILLIS * def.intervalSecs);
       expect(ret.name).to.equal('Generator0.1');
       expect(ret.funcName).to.equal('func');
       expect(ret.onProgress.name).to.equal('dummyOnProgress');
@@ -84,7 +85,7 @@ describe('test/repeater/repeater.js >', () => {
     'generator repeater is created', (done) => {
       const def = {
         name: 'Generator0.11',
-        interval: 10,
+        intervalSecs: 1,
         context: {},
         generatorTemplate: {
           connection: {
@@ -103,7 +104,7 @@ describe('test/repeater/repeater.js >', () => {
         dummyOnProgress);
       setTimeout(() => {
         expect(ret.handle).to.not.equal(undefined);
-        expect(ret.interval).to.equal(def.interval);
+        expect(ret.interval).to.equal(MILLIS * def.intervalSecs);
         expect(ret.name).to.equal('Generator0.11');
         expect(ret.funcName).to.equal('func');
         expect(tracker['Generator0.11']._bulk).to.equal(ret.handle);
@@ -115,7 +116,7 @@ describe('test/repeater/repeater.js >', () => {
     'to handleCollectResponse', (done) => {
       const obj = {
         name: 'Generator0.2',
-        interval: 6000,
+        intervalSecs: 6,
         context: {},
         generatorTemplate: {
           connection: {
@@ -132,12 +133,12 @@ describe('test/repeater/repeater.js >', () => {
       };
       repeater.createGeneratorRepeater(obj, dummyFunc, dummyOnProgress);
       obj.name = 'Generator0.2';
-      obj.interval = 60000;
+      obj.intervalSecs = 60;
       repeater.stop(obj.name);
       const ret = repeater.createGeneratorRepeater(obj, dummyFunc,
         dummyOnProgress);
       expect(ret.handle).to.not.equal(undefined);
-      expect(ret).to.have.property('interval', obj.interval);
+      expect(ret).to.have.property('interval', MILLIS * obj.intervalSecs);
       expect(ret).to.have.property('name', 'Generator0.2');
       expect(ret).to.have.property('funcName', 'func');
       expect(ret.onProgress).to.have.property('name', 'dummyOnProgress');


### PR DESCRIPTION
... now that the value is coming from Refocus.

Set the repeater interval millis based on the generator interval secs.
Update generators in tests to include the expected "intervalSecs" attribute.

Plus some random cleanup:
- make sure the top-level "describe" in all the test modules is the file name