### PR TITLE
Handle heartbeat errors by pausing/resuming generator repeaters,…

### DIFF
--- a/src/commands/start.js
+++ b/src/commands/start.js
@@ -39,8 +39,7 @@ function execute() {
 
   return doPost(url, cr.accessToken, cr.proxy, body)
   .then((res) => {
-    const sanitized = sanitize(res.body, ['token']);
-    debug('start execute response body %O', sanitized);
+    debug('start execute response body %O', sanitize(res.body));
 
     cr.collectorToken = res.body.token;
 

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -128,7 +128,8 @@ function getConfig() {
 } // getConfig
 
 module.exports = {
+  attributesToSanitize: ['accessToken', 'collectorToken', 'token'],
+  clearConfig, // exported for testing
   initializeConfig,
   getConfig,
-  clearConfig, // exported for testing
 };

--- a/src/heartbeat/heartbeat.js
+++ b/src/heartbeat/heartbeat.js
@@ -43,6 +43,6 @@ module.exports = () => {
 
   return httpUtils.doPost(urlToPost, cr.collectorToken, cr.proxy, requestbody,
     cutoff)
-  .then((res) => listener(null, res.body))
-  .catch((err) => listener(err, null));
+  .then((res) => listener.onSuccess(res.body))
+  .catch(listener.onError);
 };

--- a/src/heartbeat/heartbeat.js
+++ b/src/heartbeat/heartbeat.js
@@ -16,8 +16,8 @@ const configModule = require('../config/config');
 const listener = require('./listener');
 const httpUtils = require('../utils/httpUtils');
 const u = require('../utils/commonUtils');
-const heartbeatCutoffPercentage = require('../constants').heartbeatCutoffPercentage;
-const sanitize = u.sanitize;
+const heartbeatCutoffPercentage =
+  require('../constants').heartbeatCutoffPercentage;
 
 /**
  * Send a heartbeat to the Refocus server
@@ -27,17 +27,12 @@ module.exports = () => {
   debug('Entered heartbeat');
   const timestamp = Date.now();
   const config = configModule.getConfig();
-  const sanitized = sanitize(config.refocus, ['accessToken', 'collectorToken']);
+  const cr = config.refocus;
+  const sanitized = u.sanitize(cr, configModule.attributesToSanitize);
   debug('heartbeat config.refocus %O', sanitized);
-  const collectorName = config.name;
-  const refocusUrl = config.refocus.url;
-  const collectorToken = config.refocus.collectorToken;
-  const proxy = config.refocus.proxy;
-  const heartbeatEndpoint = `/v1/collectors/${collectorName}/heartbeat`;
-  const urlToPost = refocusUrl + heartbeatEndpoint;
-  const cutoff = config.refocus.heartbeatIntervalMillis * heartbeatCutoffPercentage;
-
-  const existing = configModule.getConfig().metadata;
+  const urlToPost = `${cr.url}/v1/collectors/${config.name}/heartbeat`;
+  const cutoff = cr.heartbeatIntervalMillis * heartbeatCutoffPercentage;
+  const existing = config.metadata;
   const current = u.getCurrentMetadata();
   const changed = u.getChangedMetadata(existing, current);
   Object.assign(existing, current);
@@ -46,7 +41,8 @@ module.exports = () => {
     collectorConfig: changed,
   };
 
-  return httpUtils.doPost(urlToPost, collectorToken, proxy, requestbody, cutoff)
+  return httpUtils.doPost(urlToPost, cr.collectorToken, cr.proxy, requestbody,
+    cutoff)
   .then((res) => listener(null, res.body))
   .catch((err) => listener(err, null));
 };

--- a/src/heartbeat/listener.js
+++ b/src/heartbeat/listener.js
@@ -16,6 +16,29 @@ const utils = require('./utils');
 const configModule = require('../config/config');
 const collectorStatus = require('../constants').collectorStatus;
 const sanitize = require('../utils/commonUtils').sanitize;
+const repeater = require('../repeater/repeater');
+
+let pausedAfterHeartbeatError = false;
+
+function onError(err) {
+  try {
+    debug('heartbeat error %O', err);
+    logger.error('heartbeat error: ', err.message);
+
+    // Pause all the repeater generators until successful heartbeat.
+    repeater.pauseGenerators();
+    pausedAfterHeartbeatError = true;
+    return err; // returning the error here just for testability
+  } catch (err) {
+    /*
+     * Catching and handling here so it doesn't bubble up and get caught by
+     * heartbeat.js, which should only be catching errors from the POST.
+     */
+    debug('heartbeat listener.onError error %O', err);
+    logger.error('heartbeat listener.onError error: ', err.message);
+    return err; // returning the error here just for testability
+  }
+} // onError
 
 /**
  * Handle the heartbeat response:
@@ -23,33 +46,42 @@ const sanitize = require('../utils/commonUtils').sanitize;
  *  2. Start, delete and update the generator repeaters as needed.
  *
  * @param {Object} err - Error from the heartbeat response
- * @param {Object} res - Heartbeat response
+ * @param {Object} res - Heartbeat response body
  * @returns {Object} - config object. An error object is returned if this
  *  function is called with the error as the first argument.
  */
 module.exports = (err, res) => {
-  debug('entered heartbeat listener');
-  if (err) {
-    debug('heartbeat listener error %O', err);
-    logger.error('The heartbeat listener was called with an error: ',
-      err.message);
-    return err;
-  }
-
-  const config = configModule.getConfig();
-  if (res && res.collectorConfig) {
-    const cc = res.collectorConfig;
-    utils.changeCollectorStatus(config.refocus.status, cc.status);
-    utils.updateCollectorConfig(cc);
-    if (cc.status === collectorStatus.RUNNING) {
-      utils.addGenerators(res);
-      utils.deleteGenerators(res);
-      utils.updateGenerators(res);
+  debug('entered heartbeat listener %s', (err ? 'with error' : ''));
+  if (err) return onError(err);
+  try {
+    const config = configModule.getConfig();
+    if (res && res.collectorConfig) {
+      const cc = res.collectorConfig;
+      utils.changeCollectorStatus(config.refocus.status, cc.status);
+      utils.updateCollectorConfig(cc);
+      if (cc.status === collectorStatus.RUNNING) {
+        utils.addGenerators(res);
+        utils.deleteGenerators(res);
+        utils.updateGenerators(res);
+      }
     }
-  }
 
-  const sanitized =
-    sanitize(config, ['accessToken', 'collectorToken', 'token']);
-  debug('exiting heartbeat listener %O', sanitized);
-  return config;
+    // Resume all the repeater generators if paused due to failed heartbeat.
+    if (pausedAfterHeartbeatError) {
+      repeater.resumeGenerators();
+      pausedAfterHeartbeatError = false;
+    }
+
+    const sanitized = sanitize(config, configModule.attributesToSanitize);
+    debug('exiting heartbeat listener %O', sanitized);
+    return config; // returning the config here just for testability
+  } catch (err) {
+    /*
+     * Catching and handling here so it doesn't bubble up and get caught by
+     * heartbeat.js, which should only be catching errors from the POST.
+     */
+    debug('heartbeat listener error %O', err);
+    logger.error('heartbeat listener error: ', err.message);
+    return err; // returning the error here just for testability
+  }
 };

--- a/src/heartbeat/listener.js
+++ b/src/heartbeat/listener.js
@@ -20,49 +20,44 @@ const repeater = require('../repeater/repeater');
 
 let pausedAfterHeartbeatError = false;
 
+/**
+ * Handle heartbeat error by pausing all the generator repeaters and setting
+ * pausedAfterHeartbeatError to true, so that they will be resumed on the next
+ * successful heartbeat.
+ *
+ * @param {Object} err - Error from the heartbeat response
+ * @returns {Error} - returning this just for testability
+ */
 function onError(err) {
-  try {
-    debug('heartbeat error %O', err);
-    logger.error('heartbeat error: ', err.message);
-
-    // Pause all the repeater generators until successful heartbeat.
-    repeater.pauseGenerators();
-    pausedAfterHeartbeatError = true;
-    return err; // returning the error here just for testability
-  } catch (err) {
-    /*
-     * Catching and handling here so it doesn't bubble up and get caught by
-     * heartbeat.js, which should only be catching errors from the POST.
-     */
-    debug('heartbeat listener.onError error %O', err);
-    logger.error('heartbeat listener.onError error: ', err.message);
-    return err; // returning the error here just for testability
-  }
+  debug('heartbeat/listener.onError: %O', err);
+  logger.error('heartbeat error: ', err.message);
+  repeater.pauseGenerators();
+  pausedAfterHeartbeatError = true;
+  return err;
 } // onError
 
 /**
  * Handle the heartbeat response:
  *  1. Update the collector config if the config has changed.
  *  2. Start, delete and update the generator repeaters as needed.
+ *  3. If generator repeaters were paused after a failed heartbeat, resume
+ *     them now.
  *
- * @param {Object} err - Error from the heartbeat response
- * @param {Object} res - Heartbeat response body
- * @returns {Object} - config object. An error object is returned if this
- *  function is called with the error as the first argument.
+ * @param {Object} body - Heartbeat response body
+ * @returns {Object} - Config object or error (returning just for testability)
  */
-module.exports = (err, res) => {
-  debug('entered heartbeat listener %s', (err ? 'with error' : ''));
-  if (err) return onError(err);
+function onSuccess(body) {
+  debug('heartbeat/listener.onSuccess', body);
   try {
     const config = configModule.getConfig();
-    if (res && res.collectorConfig) {
-      const cc = res.collectorConfig;
+    if (body && body.collectorConfig) {
+      const cc = body.collectorConfig;
       utils.changeCollectorStatus(config.refocus.status, cc.status);
       utils.updateCollectorConfig(cc);
       if (cc.status === collectorStatus.RUNNING) {
-        utils.addGenerators(res);
-        utils.deleteGenerators(res);
-        utils.updateGenerators(res);
+        utils.addGenerators(body);
+        utils.deleteGenerators(body);
+        utils.updateGenerators(body);
       }
     }
 
@@ -73,15 +68,20 @@ module.exports = (err, res) => {
     }
 
     const sanitized = sanitize(config, configModule.attributesToSanitize);
-    debug('exiting heartbeat listener %O', sanitized);
+    debug('exiting heartbeat/listener.onSuccess %O', sanitized);
     return config; // returning the config here just for testability
   } catch (err) {
     /*
      * Catching and handling here so it doesn't bubble up and get caught by
      * heartbeat.js, which should only be catching errors from the POST.
      */
-    debug('heartbeat listener error %O', err);
-    logger.error('heartbeat listener error: ', err.message);
+    debug('heartbeat/listener.onSuccess error %O', err);
+    logger.error('Error in heartbeat/listener.onSuccess: ', err.message);
     return err; // returning the error here just for testability
   }
+} // onSuccess
+
+module.exports = {
+  onError,
+  onSuccess,
 };

--- a/src/heartbeat/utils.js
+++ b/src/heartbeat/utils.js
@@ -132,6 +132,7 @@ function setupRepeater(generator) {
  * @param  {Object} collConf - The collectorConfig from the start or heartbeat
  *  response
  * @returns {Object} the buffered queue object
+ * @throws {Error} Validation error if missing collector config
  */
 function createOrUpdateGeneratorQueue(qName, token, flushFunctionCutoff, collConf) {
   debug('createOrUpdateGeneratorQueue "%s" (%s) %O',
@@ -197,12 +198,11 @@ function addGenerators(res) {
       if (cr.proxy) g.refocus.proxy = cr.proxy;
 
       config.generators[g.name] = g;
-
-      // queue name same as generator name
-      createOrUpdateGeneratorQueue(g.name, g.token, g.intervalSecs,
-        res.collectorConfig || {});
   
       try {
+        // queue name same as generator name
+        createOrUpdateGeneratorQueue(g.name, g.token, g.intervalSecs,
+          res.collectorConfig || {});
         setupRepeater(g);
       } catch (err) {
         debug('addGenerators error for generator "%s":\n%s', g.name,
@@ -273,8 +273,10 @@ function updateGenerators(res) {
         repeater.stop(g.name);
         setupRepeater(g);
       } catch (err) {
+        debug('updateGenerators error for generator "%s":\n%s', g.name,
+          err.message);
         logger.error(`updateGenerators error for generator "${g.name}":\n`,
-          err);
+          err.message);
       }
 
       debug('Generator updated: %O', sanitize(g));

--- a/src/heartbeat/utils.js
+++ b/src/heartbeat/utils.js
@@ -198,7 +198,7 @@ function addGenerators(res) {
       if (cr.proxy) g.refocus.proxy = cr.proxy;
 
       config.generators[g.name] = g;
-  
+
       try {
         // queue name same as generator name
         createOrUpdateGeneratorQueue(g.name, g.token, g.intervalSecs,
@@ -210,7 +210,7 @@ function addGenerators(res) {
         logger.error(`addGenerators error for generator "${g.name}":\n`,
           err.message);
       }
-  
+
       debug('Generator added: %O', sanitize(g));
     });
   } else {

--- a/src/repeater/repeater.js
+++ b/src/repeater/repeater.js
@@ -19,17 +19,8 @@ const u = require('../utils/commonUtils');
 
 /**
  * Tracks all the repeaters defined in the collectors.
- * The tracker object looks like this:
- *  {
- *    'heartbeat': repeatHandle,
- *    'generator1' : { // when bulk is true
- *      _bulk: repeatHandle,
- *    }
- *    'generator2' : { // when bullk is false
- *      subject1: repeatHandle,
- *      subject2: repeatHandle,
- *    }
- *  }
+ * Each key in the tracker is the name of the repeater ('heartbeat', or a
+ * generator name), and the value is the repeater handle object.
  */
 const tracker = {};
 
@@ -46,7 +37,9 @@ function notHeartbeat(key) {
  * @param  {Object} def - Repeater definition object
  */
 function trackRepeater(def) {
+  debug('trackRepeater %s', def.name);
   tracker[def.name] = def.handle;
+  debug('now tracking %O', Object.keys(tracker));
 } // trackRepeater
 
 /**
@@ -87,6 +80,7 @@ function onFailure(err) {
  * @param {String} newState - New start of the repeat
  */
 function changeRepeatState(name, newState) {
+  debug('changeRepeatState %s to %s', name, newState);
   if (!name || !tracker[name]) {
     throw new errors.ResourceNotFoundError(`Repeater "${name}" not found`);
   }
@@ -109,13 +103,20 @@ function changeRepeatState(name, newState) {
  * @throws {ValidationError} If "obj" does not have a name attribute.
  */
 function stop(name) {
-  changeRepeatState(name, 'stop');
+  debug('stop %s', name);
+  try {
+    changeRepeatState(name, 'stop');
+  } catch(err) {
+    logger.error(err);
+  }
+
   delete tracker[name];
   paused.delete(name);
   logger.info({
     activity: 'repeater:stopped',
     name,
   });
+  debug('now tracking %O', Object.keys(tracker));
 } // stop
 
 /**
@@ -124,8 +125,9 @@ function stop(name) {
  * @returns {Object} The tracker object tracking all the repeats
  */
 function stopAllRepeaters() {
-  debug('Entered repeater.stopAllRepeaters');
+  debug('stopAllRepeaters');
   Object.keys(tracker).forEach(stop);
+  debug('now tracking %O', Object.keys(tracker));
   return tracker;
 } // stopAllRepeaters
 
@@ -134,6 +136,7 @@ function stopAllRepeaters() {
  * @param  {String} name - Name of the repeat
  */
 function pause(name) {
+  debug('pause %s', name);
   changeRepeatState(name, 'pause');
   paused.add(name);
   logger.info({
@@ -146,6 +149,7 @@ function pause(name) {
  * Pauses all the generator repeaters.
  */
 function pauseGenerators() {
+  debug('pauseGenerators');
   Object.keys(tracker).filter(notHeartbeat).forEach(pause);
 } // pauseGenerators
 
@@ -154,6 +158,7 @@ function pauseGenerators() {
  * @param  {String} name - Name of the repeat
  */
 function resume(name) {
+  debug('resume %s', name);
   changeRepeatState(name, 'resume');
   paused.delete(name);
   logger.info({
@@ -166,6 +171,7 @@ function resume(name) {
  * Resumes all the generator repeaters.
  */
 function resumeGenerators() {
+  debug('pauseGenerators');
   Object.keys(tracker).filter(notHeartbeat).forEach(resume);
 } // resumeGenerators
 
@@ -188,6 +194,7 @@ function validateDefinition(def) {
   debug('validateDefinition %O', def);
   const val = repeaterSchema.validate(def);
   if (val.error) {
+    debug('validateDefinition error', val);
     throw new errors.ValidationError(val.error.message);
   }
 
@@ -215,7 +222,7 @@ function validateDefinition(def) {
  */
 function create(def) {
   validateDefinition(def);
-  debug('Creating %O', def);
+  debug('create %O', def);
   const handle = repeat(def.func);
   handle.every(def.interval, 'ms').start.now();
   handle.then(def.onSuccess || onSuccess, def.onFailure || onFailure,
@@ -252,7 +259,6 @@ function createGeneratorRepeater(generator, func, onProgress) {
     func: () => func(generator),
     onProgress,
     bulk: u.isBulk(generator),
-    subjects: generator.subjects,
   });
 } // createGeneratorRepeater
 

--- a/src/repeater/repeater.js
+++ b/src/repeater/repeater.js
@@ -106,7 +106,7 @@ function stop(name) {
   debug('stop %s', name);
   try {
     changeRepeatState(name, 'stop');
-  } catch(err) {
+  } catch (err) {
     logger.error(err);
   }
 

--- a/src/repeater/repeater.js
+++ b/src/repeater/repeater.js
@@ -258,7 +258,6 @@ function createGeneratorRepeater(generator, func, onProgress) {
     interval: 1000 * generator.intervalSecs, // convert to millis
     func: () => func(generator),
     onProgress,
-    bulk: u.isBulk(generator),
   });
 } // createGeneratorRepeater
 

--- a/src/utils/commonUtils.js
+++ b/src/utils/commonUtils.js
@@ -135,10 +135,11 @@ module.exports = {
    * Return a copy of the object with the specified keys masked.
    *
    * @param  {Object} object - Object to be masked
-   * @param  {Array} keys - The keys of the object to be masked
+   * @param  {Array} keys - The keys of the object to be masked, defaults to
+   *  ["token"] if none provided
    * @returns {Object} - returns the object with the keys masked
    */
-  sanitize(object, keys) {
+  sanitize(object, keys = ['token']) {
     if (!Array.isArray(keys)) {
       return object;
     }

--- a/src/utils/queue.js
+++ b/src/utils/queue.js
@@ -24,7 +24,7 @@ const sanitize = require('./commonUtils').sanitize;
  * @returns {Object} The new buffered queue object
  */
 function create(queueParams) {
-  const sanitized = sanitize(queueParams, ['token']);
+  const sanitized = sanitize(queueParams);
   debug('Create queue %O', sanitized);
   const q = new Queue(queueParams.name, {
     size: queueParams.size,

--- a/src/utils/schema.js
+++ b/src/utils/schema.js
@@ -20,7 +20,6 @@ const repeater = Joi.object().keys({
   onFailure: Joi.func(),
   onProgress: Joi.func(),
   bulk: Joi.boolean(),
-  subjects: Joi.array().min(1).items(Joi.object()),
   handle: Joi.any(),
   funcName: Joi.string(),
 });

--- a/test/heartbeat/heartbeat.js
+++ b/test/heartbeat/heartbeat.js
@@ -208,8 +208,7 @@ describe('test/heartbeat/heartbeat.js >', () => {
     heartbeat()
     .then((err) => {
       expect(err.response.status).to.equal(httpStatus.FORBIDDEN);
-      expect(err.response.body).deep
-        .equal(errorResponse);
+      expect(err.response.body).deep.equal(errorResponse);
       done();
     })
     .catch(done);
@@ -342,7 +341,10 @@ describe('test/heartbeat/heartbeat.js >', () => {
 
   it('Ok, collector status in heartbeat full cycle ' +
     'Running->Pause->Running->Stop', (done) => {
-    const reply = [{ absolutePath: 'S1.S2', name: 'S1' }, { absolutePath: 'S1.S2', name: 'S2' }];
+    const reply = [
+      { absolutePath: 'S1.S2', name: 'S1' },
+      { absolutePath: 'S1.S2', name: 'S2' },
+    ];
 
     // set up mock endpoints to get subjects from
     // generator2 endpoint

--- a/test/heartbeat/listener.js
+++ b/test/heartbeat/listener.js
@@ -79,7 +79,7 @@ describe('test/heartbeat/listener.js >', () => {
   });
 
   it('added generators should be added to the config and the repeat tracker ' +
-    'should be setup', (done) => {
+    'should be setup; pause/resume after heartbeat error', (done) => {
     const res = {
       collectorConfig: {
         heartbeatIntervalMillis: 50,
@@ -103,6 +103,16 @@ describe('test/heartbeat/listener.js >', () => {
     expect(updatedConfig.generators.Core_Trust2)
       .to.deep.equal(res.generatorsAdded[0]);
     expect(tracker.Core_Trust2).not.equal(undefined);
+
+    // send error to listener, check for paused generator repeaters
+    listener(new Error('this is error'));
+    expect(repeater.paused).to.have.property('size', 1);
+    expect(repeater.paused).to.include('Core_Trust2');
+
+    // send ok response to listener, check for resumed generator repeaters
+    const afterOK = listener(null, res);
+    expect(repeater.paused).to.have.property('size', 0);
+
     done();
   });
 

--- a/test/heartbeat/listener.js
+++ b/test/heartbeat/listener.js
@@ -64,13 +64,13 @@ describe('test/heartbeat/listener.js >', () => {
   it('should handle errors passed to the function', (done) => {
     const err = { status: 404,
       description: 'heartbeat not received', };
-    const ret = listener(err, hbResponse);
+    const ret = listener.onError(err);
     expect(ret).to.deep.equal(err);
     done();
   });
 
   it('collector config should be updated', (done) => {
-    const updatedConfig = listener(null, hbResponse);
+    const updatedConfig = listener.onSuccess(hbResponse);
     expect(updatedConfig.refocus.heartbeatIntervalMillis)
       .to.equal(hbResponse.collectorConfig.heartbeatIntervalMillis);
     expect(updatedConfig.refocus.status)
@@ -99,19 +99,98 @@ describe('test/heartbeat/listener.js >', () => {
         },
       ],
     };
-    const updatedConfig = listener(null, res);
+    const updatedConfig = listener.onSuccess(res);
     expect(updatedConfig.generators.Core_Trust2)
       .to.deep.equal(res.generatorsAdded[0]);
     expect(tracker.Core_Trust2).not.equal(undefined);
 
     // send error to listener, check for paused generator repeaters
-    listener(new Error('this is error'));
+    listener.onError(new Error('this is error'));
     expect(repeater.paused).to.have.property('size', 1);
     expect(repeater.paused).to.include('Core_Trust2');
 
-    // send ok response to listener, check for resumed generator repeaters
-    const afterOK = listener(null, res);
-    expect(repeater.paused).to.have.property('size', 0);
+    // send ok response with updated generator - repeater should be unpaused
+    const resUpd = {
+      collectorConfig: {
+        heartbeatIntervalMillis: 50,
+        maxSamplesPerBulkUpsert: 10,
+        status: 'Running',
+      },
+      generatorsUpdated: [
+        {
+          name: 'Core_Trust2',
+          generatorTemplateName: 'refocus-trust1-collector',
+          generatorTemplate: sgt,
+          subjectQuery: 'absolutePath=Parent.Child.*&tags=Secondary',
+          context: { baseTrustUrl: 'https://example.api' },
+          possibleCollectors: [{ name: 'agent1' }],
+          intervalSecs: 6,
+          token: 'asd123asd',
+        },
+      ],
+    };
+    const afterUpdate = listener.onSuccess(resUpd);
+    expect(afterUpdate.generators.Core_Trust2)
+    .to.have.property('subjectQuery',
+      'absolutePath=Parent.Child.*&tags=Secondary');
+    expect(repeater.paused).to.be.empty;
+
+    done();
+  });
+
+  it('delete a paused generator', (done) => {
+    const res = {
+      collectorConfig: {
+        heartbeatIntervalMillis: 50,
+        maxSamplesPerBulkUpsert: 10,
+        status: 'Running',
+      },
+      generatorsAdded: [
+        {
+          name: 'Core_Trust2',
+          generatorTemplateName: 'refocus-trust1-collector',
+          generatorTemplate: sgt,
+          subjectQuery: 'absolutePath=Parent.Child.*&tags=Primary',
+          context: { baseTrustUrl: 'https://example.api' },
+          possibleCollectors: [{ name: 'agent1' }],
+          intervalSecs: 6,
+          token: 'asd123asd',
+        },
+      ],
+    };
+    const updatedConfig = listener.onSuccess(res);
+    expect(updatedConfig.generators.Core_Trust2)
+      .to.deep.equal(res.generatorsAdded[0]);
+    expect(tracker.Core_Trust2).not.equal(undefined);
+
+    // send error to listener, check for paused generator repeaters
+    listener.onError(new Error('this is error'));
+    expect(repeater.paused).to.have.property('size', 1);
+    expect(repeater.paused).to.include('Core_Trust2');
+
+    // send ok response with updated generator - repeater should be unpaused
+    const resDel = {
+      collectorConfig: {
+        heartbeatIntervalMillis: 50,
+        maxSamplesPerBulkUpsert: 10,
+        status: 'Running',
+      },
+      generatorsDeleted: [
+        {
+          name: 'Core_Trust2',
+          generatorTemplateName: 'refocus-trust1-collector',
+          generatorTemplate: sgt,
+          subjectQuery: 'absolutePath=Parent.Child.*&tags=Secondary',
+          context: { baseTrustUrl: 'https://example.api' },
+          possibleCollectors: [{ name: 'agent1' }],
+          intervalSecs: 6,
+          token: 'asd123asd',
+        },
+      ],
+    };
+    const afterDelete = listener.onSuccess(resDel);
+    expect(afterDelete.generators).to.not.have.key('Core_Trust2');
+    expect(repeater.paused).to.be.empty;
 
     done();
   });
@@ -136,7 +215,7 @@ describe('test/heartbeat/listener.js >', () => {
         },
       ],
     };
-    listener(null, res);
+    listener.onSuccess(res);
     hbResponse.generatorsUpdated = [
       {
         name: 'Core_Trust3',
@@ -148,7 +227,7 @@ describe('test/heartbeat/listener.js >', () => {
       },
     ];
     hbResponse.generatorsAdded = [];
-    const updatedConfig = listener(null, hbResponse);
+    const updatedConfig = listener.onSuccess(hbResponse);
     expect(updatedConfig.generators.Core_Trust3.context.baseTrustUrl)
       .to.deep.equal('https://example.api');
     expect(tracker.Core_Trust3).not.equal(null);
@@ -177,7 +256,7 @@ describe('test/heartbeat/listener.js >', () => {
         },
       ],
     };
-    const updatedConfig = listener(null, res);
+    const updatedConfig = listener.onSuccess(res);
     expect(updatedConfig.generators.Core_Trust_nonBulk_NA1_NA2)
       .to.deep.equal(res.generatorsAdded[0]);
     expect(tracker.Core_Trust_nonBulk_NA1_NA2.NA1).not.equal(undefined);
@@ -207,7 +286,7 @@ describe('test/heartbeat/listener.js >', () => {
       ],
     };
 
-    let updatedConfig = listener(null, res);
+    let updatedConfig = listener.onSuccess(res);
     expect(updatedConfig.generators.bulktrueToBulkFalse_1)
       .to.deep.equal(res.generatorsAdded[0]);
     expect(tracker.bulktrueToBulkFalse_1._bulk).not.equal(undefined);
@@ -232,7 +311,7 @@ describe('test/heartbeat/listener.js >', () => {
       ],
     };
 
-    updatedConfig = listener(null, updatedRes);
+    updatedConfig = listener.onSuccess(updatedRes);
     expect(updatedConfig.generators.bulktrueToBulkFalse_1)
       .to.deep.equal(updatedRes.generatorsUpdated[0]);
     expect(tracker.bulktrueToBulkFalse_1.NA1).not.equal(undefined);
@@ -262,7 +341,7 @@ describe('test/heartbeat/listener.js >', () => {
         },
       ],
     };
-    let updatedConfig = listener(null, res);
+    let updatedConfig = listener.onSuccess(res);
     expect(updatedConfig.generators.bulktrueToBulkFalse_2)
       .to.deep.equal(res.generatorsAdded[0]);
     expect(tracker.bulktrueToBulkFalse_2.NA1).not.equal(undefined);
@@ -287,7 +366,7 @@ describe('test/heartbeat/listener.js >', () => {
         },
       ],
     };
-    updatedConfig = listener(null, updatedRes);
+    updatedConfig = listener.onSuccess(updatedRes);
     expect(updatedConfig.generators.bulktrueToBulkFalse_2)
       .to.deep.equal(updatedRes.generatorsUpdated[0]);
     expect(tracker.bulktrueToBulkFalse_2._bulk).not.equal(undefined);
@@ -324,7 +403,7 @@ describe('test/heartbeat/listener.js >', () => {
         },
       ],
     };
-    const updatedConfig = listener(null, res);
+    const updatedConfig = listener.onSuccess(res);
     expect(updatedConfig.generators.ABC_DATA).to.not.equal(undefined);
     const resDel = {
       collectorConfig: {
@@ -336,7 +415,7 @@ describe('test/heartbeat/listener.js >', () => {
         { name: 'ABC_DATA', },
       ],
     };
-    const updatedConfigAgain = listener(null, resDel);
+    const updatedConfigAgain = listener.onSuccess(resDel);
     expect(Object.keys(tracker)).to.contain('Fghijkl_Mnopq');
     expect(updatedConfigAgain.generators.Fghijkl_Mnopq)
       .to.not.equal(undefined);
@@ -369,7 +448,7 @@ describe('test/heartbeat/listener.js >', () => {
         context: { baseTrustUrl: 'https://example.api', },
       },
     };
-    const ret = listener(null, res);
+    const ret = listener.onSuccess(res);
     expect(ret.refocus.heartbeatIntervalMillis).to.equal(50);
     done();
   });
@@ -409,7 +488,7 @@ describe('test/heartbeat/listener.js >', () => {
           },
         ],
       };
-      const updatedConfig = listener(null, res);
+      const updatedConfig = listener.onSuccess(res);
       const decryptedContext = updatedConfig.generators
         .Core_Trust2_With_Encryption.context;
 
@@ -466,7 +545,7 @@ describe('test/heartbeat/listener.js >', () => {
           },
         ],
       };
-      listener(null, res);
+      listener.onSuccess(res);
       const newPassword = 'newPassword';
       const newToken = 'newToken';
       hbResponse.generatorsUpdated = [
@@ -503,7 +582,7 @@ describe('test/heartbeat/listener.js >', () => {
         },
       ];
       hbResponse.generatorsAdded = [];
-      const updatedConfig = listener(null, hbResponse);
+      const updatedConfig = listener.onSuccess(hbResponse);
       expect(updatedConfig.generators.Core_Trust3_With_Encryption.context)
         .to.deep.equal({ baseTrustUrl: 'https://example.api.v2',
           password: newPassword, token: newToken, });
@@ -554,7 +633,7 @@ describe('test/heartbeat/listener.js >', () => {
           },
         ],
       };
-      listener(null, res);
+      listener.onSuccess(res);
       const newPassword = 'newPassword';
       const newToken = 'newToken';
       hbResponse.generatorsUpdated = [
@@ -591,7 +670,7 @@ describe('test/heartbeat/listener.js >', () => {
         },
       ];
       hbResponse.generatorsAdded = [];
-      const updatedConfig = listener(null, hbResponse);
+      const updatedConfig = listener.onSuccess(hbResponse);
       expect(updatedConfig.generators.Core_Trust3_With_Encryption.context)
         .to.deep.equal({ baseTrustUrl: 'https://example.api.v2',
           password: newPassword, token: newToken, });

--- a/test/heartbeat/utils.js
+++ b/test/heartbeat/utils.js
@@ -293,7 +293,7 @@ describe('test/heartbeat/utils.js >', () => {
                 bulk: true,
               },
             },
-            intervalSecs: -3,
+            intervalSecs: -3, // Invalid!
             subjectQuery: '?absolutePath=Canada',
           },
         ],
@@ -305,6 +305,8 @@ describe('test/heartbeat/utils.js >', () => {
       const qGen2 = q.get(genName2);
       expect(qGen1._size).to.be.equal(1000);
       expect(qGen2._size).to.be.equal(1000);
+      expect(repeater.tracker).to.have.key('Gen1');
+      expect(repeater.tracker).to.not.have.key('Gen2');
       done();
     });
   });

--- a/test/heartbeat/utils.js
+++ b/test/heartbeat/utils.js
@@ -263,7 +263,7 @@ describe('test/heartbeat/utils.js >', () => {
 
     after(() => configModule.clearConfig());
 
-    it('different queues are created for different generators', (done) => {
+    it('queues and repeaters are created for valid generators', (done) => {
       const heartbeatResp = {
         collectorConfig: {
           heartbeatIntervalMillis: 50,
@@ -293,7 +293,7 @@ describe('test/heartbeat/utils.js >', () => {
                 bulk: true,
               },
             },
-            intervalSecs: 3,
+            intervalSecs: -3,
             subjectQuery: '?absolutePath=Canada',
           },
         ],

--- a/test/repeater/repeater.js
+++ b/test/repeater/repeater.js
@@ -333,7 +333,7 @@ describe('test/repeater/repeater.js >', () => {
       }, 500);
     });
 
-    it('error if repeater being stopped is not in the tracker', (done) => {
+    it('noop if repeater being stopped is not in the tracker', (done) => {
       const obj = {
         name: 'someRandomName',
         interval: 10,
@@ -341,12 +341,8 @@ describe('test/repeater/repeater.js >', () => {
 
       try {
         repeater.stop(obj);
-        done('Expecting ResourceNotFoundError');
+        done();
       } catch (err) {
-        if (err.name === 'ResourceNotFoundError') {
-          return done();
-        }
-
         return done(err);
       }
     });

--- a/test/repeater/repeater.js
+++ b/test/repeater/repeater.js
@@ -605,8 +605,14 @@ describe('test/repeater/repeater.js >', () => {
 
     it('null subjects', (done) => {
       try {
-        const def =
-          { name: 'Gen', interval: 10, func: () => {}, subjects: null };
+        const func = () => {};
+
+        const def = {
+          name: 'Gen',
+          interval: 10,
+          func,
+          subjects: null,
+        };
         repeater.create(def);
         return done('Expecting ValidationError');
       } catch (err) {

--- a/test/repeater/repeater.js
+++ b/test/repeater/repeater.js
@@ -602,5 +602,21 @@ describe('test/repeater/repeater.js >', () => {
         return done();
       }
     });
+
+    it('null subjects', (done) => {
+      try {
+        const def =
+          { name: 'Gen', interval: 10, func: () => {}, subjects: null };
+        repeater.create(def);
+        return done('Expecting ValidationError');
+      } catch (err) {
+        if (err.name === 'ValidationError' &&
+        err.message === '"subjects" is not allowed') {
+          return done();
+        }
+
+        return done(err);
+      }
+    });
   });
 });

--- a/test/repeater/repeater.js
+++ b/test/repeater/repeater.js
@@ -377,10 +377,10 @@ describe('test/repeater/repeater.js >', () => {
 
   describe('pause and resume >', () => {
     it('OK even when tracker is empty', (done) => {
-      let _tracker = repeater.pauseGenerators();
-      expect(_tracker).to.deep.equal({});
-      _tracker = repeater.resumeGenerators();
-      expect(_tracker).to.deep.equal({});
+      repeater.pauseGenerators();
+      expect(repeater.paused).to.have.property('size', 0);
+      repeater.resumeGenerators();
+      expect(repeater.paused).to.have.property('size', 0);
       done();
     });
 

--- a/test/utils/commonUtils.js
+++ b/test/utils/commonUtils.js
@@ -48,6 +48,18 @@ describe('test/utils/commonUtils.js >', () => {
       done();
     });
 
+    it('ok, sanitize with default "keys"', (done) => {
+      const obj = {
+        token: 'a310u',
+        username: 'refocus-collector-user',
+      };
+      const sanitized = sanitize(obj);
+      expect(sanitized.token).to.contain('...');
+      expect(sanitized.token.length).to.not.equal(obj.token.length);
+      expect(sanitized.username).to.equal(obj.username);
+      done();
+    });
+
     it('ok, sanitize with a single key', (done) => {
       const obj = {
         token: 'a310u',


### PR DESCRIPTION
… remove subject from repeater validation

- src/heartbeat/listener.js
  - move error handling to separate fn for readability
  - wrap all the code in the main listener fn and the onError fn in try/catch so that errors don't bubble up and get caught by heartbeat.js itself, which should only be catching errors from the heartbeat POST request
  - if the heartbeat POST request returns an error, pause all the generator repeaters and set a new local var pausedAfterHeartbeatError to true; once we get a good heartbeat response, if pausedAfterHeartbeatError is true, resume the generator repeaters
  - sanitize config debug using attributesToSanitize instead of hard-coded array of attribute names

- src/repeater/repeater.js
  - update validateDefinition - no longer needs to check the subjects attribute - just check for duplicate name being tracked
  - update pauseGenerators/resumeGenerators - no return value needed (was only there for tests, no longer needed)
  - track names of paused generators - make it easier to test
  - add comments about errors being thrown
  - minor style changes and cleanup

- test/heartbeat/listener.js
  - confirm that generator repeaters are paused after a heartbeat error and resumed after next good heartbeat

- test/repeater/repeater.js
  - update tests to check repeater.paused

Other Changes

- src/commands/start.js
  - minor change to use the new simplified sanitize fn

- src/config/config.js
  - export the names of the attributes to sanitize when sanitizing config data (instead of hard-coding them everywhere we actually debug the config)

- src/heartbeat/heartbeat.js
  - minor style changes and cleanup
  - sanitize config debug using attributesToSanitize instead of hard-coded array of attribute names

- src/heartbeat/utils.js
  - add comments about errors being thrown
  - fix the setupRepeater function comments to reflect the "bulk vs. bySubject" work Samee did previously
  - minor style changes and cleanup
  - minor change to use the new simplified sanitize fn

- src/utils/commonUtils.js
  - simplify the way callers call the sanitize fn by setting a default value for the "keys" arg to ["token"]

- src/utils/queue.js
  - minor change to use the new simplified sanitize fn

- test/heartbeat/heartbeat.js
  - minor style changes

- test/utils/commonUtils.js
  - test sanitize fn using new keys default