### PR TITLE
Generator queue flush timeout bug fix.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ dump.rdb
 
 # Ignore registry.json
 registry.json
+
+# Ignore InteliJ Ide
+.idea/

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -58,7 +58,7 @@ function getDefaultConfig() {
    *     // POST /v1/collectors/:key/heartbeat response
    *     heartbeatIntervalMillis: [INTEGER],
    *     maxSamplesPerBulkUpsert: [INTEGER],
-   *     sampleUpsertQueueTime: [INTEGER],
+   *     sampleUpsertQueueTimeMillis: [INTEGER],
    *
    *     // plus any other parameters returned in the "collectorConfig" attribute
    *     // of the POST /v1/collectors/:key/heartbeat response

--- a/src/heartbeat/utils.js
+++ b/src/heartbeat/utils.js
@@ -148,8 +148,8 @@ function createOrUpdateGeneratorQueue(qName, token, flushFunctionCutoff, collCon
       queue.updateSize(qName, collConf.maxSamplesPerBulkUpsert);
     }
 
-    if (collConf.sampleUpsertQueueTime) {
-      queue.updateFlushTimeout(qName, collConf.sampleUpsertQueueTime);
+    if (collConf.sampleUpsertQueueTimeMillis) {
+      queue.updateFlushTimeout(qName, collConf.sampleUpsertQueueTimeMillis);
     }
 
     return queue.get(qName);
@@ -160,7 +160,7 @@ function createOrUpdateGeneratorQueue(qName, token, flushFunctionCutoff, collCon
   return queue.create({
     name: qName,
     size: cr.maxSamplesPerBulkUpsert,
-    flushTimeout: cr.sampleUpsertQueueTime,
+    flushTimeout: cr.sampleUpsertQueueTimeMillis,
     verbose: false,
     flushFunction: httpUtils.doBulkUpsert,
     proxy: cr.proxy,

--- a/test/heartbeat/heartbeat.js
+++ b/test/heartbeat/heartbeat.js
@@ -17,7 +17,6 @@ const heartbeat = require('../../src/heartbeat/heartbeat');
 const httpStatus = require('../../src/constants').httpStatus;
 const q = require('../../src/utils/queue');
 const repeater = require('../../src/repeater/repeater');
-const handleCollectResponse = require('../../src/remoteCollection/handleCollectResponse');
 const sgt = require('../sgt');
 const sinon = require('sinon');
 const logger = require('winston');
@@ -96,7 +95,7 @@ const hbResponseNoSG = {
   collectorConfig: {
     heartbeatIntervalMillis: 50,
     maxSamplesPerBulkUpsert: 10,
-    sampleUpsertQueueTime: 100,
+    sampleUpsertQueueTimeMillis: 100,
     status: 'Running',
   },
   generatorsAdded: [],

--- a/test/remoteCollection/handleCollectResponse.js
+++ b/test/remoteCollection/handleCollectResponse.js
@@ -216,7 +216,7 @@ describe('test/remoteCollection/handleCollectResponse.js >', () => {
       const qParams = {
         name: generatorName,
         size: config.refocus.maxSamplesPerBulkUpsert,
-        flushTimeout: config.refocus.sampleUpsertQueueTime,
+        flushTimeout: config.refocus.sampleUpsertQueueTimeMillis,
         verbose: false,
         token: '123abc',
         flushFunction: httpUtils.doBulkUpsert,
@@ -464,7 +464,7 @@ describe('test/remoteCollection/handleCollectResponse.js >', () => {
       const qParams = {
         name: generatorName,
         size: config.refocus.maxSamplesPerBulkUpsert,
-        flushTimeout: config.refocus.sampleUpsertQueueTime,
+        flushTimeout: config.refocus.sampleUpsertQueueTimeMillis,
         verbose: false,
         flushFunction: httpUtils.doBulkUpsert,
       };


### PR DESCRIPTION
* Refocus was sending collector config attribute name with + 'Millis' and the flush time out was not up to date. Renamed the attribute in src/config/config.js to be the same as Refocus config request;
* Added test to make sure queue.updateFlushTimeout has been called.

[W-5271413]