### PR TITLE
oauth fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -169,12 +169,12 @@
       }
     },
     "@salesforce/refocus-collector-eval": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/refocus-collector-eval/-/refocus-collector-eval-1.11.0.tgz",
-      "integrity": "sha512-VIi/WlVhzGV4IRUk3ZBTcBGdc8roVc++ZDiE1sw0cJSRDnhw0MJgTdQ9LRJKHmnRXFmGHJM378E91vPjMcM3Zw==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@salesforce/refocus-collector-eval/-/refocus-collector-eval-1.11.1.tgz",
+      "integrity": "sha512-7O1fJ6vNed7tyAU7xD7y/bsXyz7IU/9SrlwC/JJO2JRNetBIMhNFbi5b+YmZcBZfZM2+uNHI6HLykIUeP4R0jA==",
       "requires": {
         "accept-parser": "1.0.1",
-        "ajv": "6.5.5",
+        "ajv": "6.6.1",
         "errors": "0.3.0",
         "joi": "13.7.0",
         "sinon": "4.5.0",
@@ -183,9 +183,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "6.5.5",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.5.tgz",
-          "integrity": "sha512-7q7gtRQDJSyuEHjuVgHoUa2VuemFiCMrfQc9Tc08XTAc4Zj/5U1buQJ0HU6i7fKjXU09SVgSmxa4sLvuvS8Iyg==",
+          "version": "6.6.1",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.1.tgz",
+          "integrity": "sha512-ZoJjft5B+EJBjUyu9C9Hc0OZyPZSSlOF+plzouTrg6UlA8f+e/n8NIgBFG/9tppJtpPWfthHakK7juJdNDODww==",
           "requires": {
             "fast-deep-equal": "2.0.1",
             "fast-json-stable-stringify": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/refocus-collector",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/salesforce/refocus-collector#readme",
   "dependencies": {
-    "@salesforce/refocus-collector-eval": "^1.11.0",
+    "@salesforce/refocus-collector-eval": "^1.11.1",
     "bluebird": "^3.5.3",
     "commander": "^2.19.0",
     "debug": "^3.2.6",

--- a/src/remoteCollection/collect.js
+++ b/src/remoteCollection/collect.js
@@ -196,7 +196,6 @@ function prepareRemoteRequest(generator) {
       }
     }
 
-
     // Prepare headers
     generator.preparedHeaders = rce.prepareHeaders(conn.headers, context);
 

--- a/src/utils/httpUtils.js
+++ b/src/utils/httpUtils.js
@@ -145,7 +145,7 @@ function doBulkUpsert(url, userToken, intervalSecs, proxy, arr) {
 
     (err) => {
       debug('doBulkUpsert err %O', err);
-      logger.error(err.message);
+      logger.error(err);
       /*
        * Don't Promise.reject(...) this error, because there is no handler
        * for the rejection.

--- a/test/remoteCollection/collect.js
+++ b/test/remoteCollection/collect.js
@@ -492,7 +492,7 @@ describe('test/remoteCollection/collect.js >', () => {
       name: 'Generator0',
       intervalSecs: 1,
       context: {},
-      token: {
+      OAuthToken: {
         accessToken: 'eegduygsugfiusguguygyfkufyg',
       },
       generatorTemplate: {


### PR DESCRIPTION
This fixes a bug introduced while merging the queue removal changes with the oauth logic:

The created oauth token is set on the generator object as the "token" field, overwriting the refocus token. Previously this didn't cause problems because this was a cloned version of the generator object and the original version was tied to the repeater.

The new collection -> upsert flow passes the generator object all the way through the promise chain, then relies on it for the final upsert request. So when the oauth token was being set, it was overwriting the existing refocus token and it was eventually trying to use the oauth token for the upsert.

I fixed this by changing the oauth token to use a separate "OAuthToken" field name, and made some additional refinements to the oauth logic.

I also have some other changes in progress to simplify the way the generator is passed through that will remove this dependency and make it more clear exactly what is being passed through.