### PR TITLE
catch oauth error and set as generator.res

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/refocus-collector",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Collector system to automate feeding data in to the Refocus platform.",
   "main": "index.js",
   "directories": {

--- a/src/constants.js
+++ b/src/constants.js
@@ -45,4 +45,12 @@ module.exports = {
   },
 
   heartbeatRepeatName: 'heartbeat',
+
+  connection: {
+    maxRetries: 3,
+    timeout: {
+      response: 10000,
+      deadline: 30000,
+    },
+  },
 };

--- a/src/remoteCollection/collect.js
+++ b/src/remoteCollection/collect.js
@@ -105,6 +105,14 @@ function sendRemoteRequest(generator) {
     return Promise.resolve(generator);
   }
 
+  /*
+   * Don't bother sending request if prepareRemoteRequest already set error as
+   * generator.res.
+   */
+  if (generator.hasOwnProperty('res') && generator.res instanceof Error) {
+    return Promise.resolve(generator);
+  }
+
   const req = generateRequest(generator);
 
   return new Promise((resolve) => {

--- a/src/remoteCollection/collect.js
+++ b/src/remoteCollection/collect.js
@@ -53,28 +53,30 @@ function requiresSSLOnly() {
 }
 
 /**
- * Helper function to set up the superagent request to connect to the remote
+ * Helper function to set up the super-agent request to connect to the remote
  * data source. Configures request timeout, retries and proxy.
  *
  * @param {Object} gen - the sample generator
  * @returns {Request} - the superagent request
  */
 function generateRequest(gen) {
-  const refconf = configModule.getConfig().refocus;
+  const refConf = configModule.getConfig().refocus;
 
   // ref. https://visionmedia.github.io/superagent/#timeouts
   const conn = gen.generatorTemplate.connection;
   const genTimeout = {
     response:
-      get(gen, 'timeout.response') || refconf.timeoutResponseMillis || 10000,
+      get(gen, 'timeout.response') || refConf.timeoutResponseMillis ||
+      constants.connection.timeout.response,
     deadline:
-      get(gen, 'timeout.deadline') || refconf.timeoutDeadlineMillis || 30000,
+      get(gen, 'timeout.deadline') || refConf.timeoutDeadlineMillis ||
+      constants.connection.timeout.deadline,
   };
   const req = request
     .get(gen.preparedUrl)
     .set(gen.preparedHeaders)
     .timeout(genTimeout)
-    .retry(refconf.maxRetries || 3);
+    .retry(refConf.maxRetries || constants.connection.maxRetries);
 
   if (conn.dataSourceProxy) {
     req.proxy(conn.dataSourceProxy);
@@ -88,8 +90,8 @@ function generateRequest(gen) {
  * Automatically retries requests if they fail in a way that is transient or
  * could be due to a flaky internet connection.
  *
- * @param  {Object} generator - the generator object
- * @return {Promise<Object>} the updated generator object with a "res"
+ * @param   {Object} generator - the generator object
+ * @returns {Promise<Object>} the updated generator object with a "res"
  *  attribute carrying the response from the remote data source
  */
 function sendRemoteRequest(generator) {
@@ -114,21 +116,19 @@ function sendRemoteRequest(generator) {
 
           // eslint-disable-next-line no-use-before-define
           return doCollect(generator)
-          .then((resp) => {
-            if (resp) {
-              debug('sendRemoteRequest returned OK');
-              generator.res = resp.res;
-            }
+            .then((resp) => {
+              if (resp) {
+                debug('sendRemoteRequest returned OK');
+                generator.res = resp.res;
+              }
 
-            return resolve(generator);
-          });
-        }
+              return resolve(generator);
+            });
+        } // shouldRequestNewToken
 
         debug('sendRemoteRequest returned error %O', err);
         generator.res = err;
-      }
-
-      if (res) {
+      } else if (res) {
         debug('sendRemoteRequest returned OK');
         generator.res = res;
       }
@@ -139,7 +139,8 @@ function sendRemoteRequest(generator) {
 } // sendRemoteRequest
 
 /**
- * Prepare and attach the token, connection, url, and headers to the generator object.
+ * Prepare and attach the token, connection, url, and headers to the generator
+ * object.
  *
  * @param  {Object} generator - The generator object
  * @returns {Promise} - which resolves to the prepared generator object
@@ -151,79 +152,90 @@ function prepareRemoteRequest(generator) {
   return Promise.resolve()
 
   // get new OAuthToken if necessary
-  .then(() => {
-    if (!generator.OAuthToken && get(generator, 'connection.simple_oauth')) {
-      if (generator.connection) {
-        generator.connection = rce.expandObject(connection, context);
+    .then(() => {
+      if (!generator.OAuthToken && get(generator, 'connection.simple_oauth')) {
+        if (generator.connection) {
+          generator.connection = rce.expandObject(connection, context);
+        }
+
+        const method = generator.connection.simple_oauth.method;
+        const simpleOauth = generator.connection.simple_oauth;
+
+        // special case for simple_oauth.salesforce
+        if (generator.connection.simple_oauth.salesforce) {
+          const credentials = {
+            clientId: simpleOauth.credentials.client.id,
+            clientSecret: simpleOauth.credentials.client.secret,
+            redirectUri: simpleOauth.credentials.client.redirectUri,
+          };
+
+          const org = nforce.createConnection(credentials);
+          return org.authenticate(simpleOauth.tokenConfig);
+        }
+
+        // otherwise when it's NOT simple_oauth.salesforce...
+        // eslint-disable-next-line global-require
+        const oauth2 = require('simple-oauth2').create(simpleOauth.credentials);
+        return oauth2[method].getToken(simpleOauth.tokenConfig)
+          .catch((err) => {
+            // Setting this Oauth error as the generator "res" attribute to
+            // force handleCollectResponse to generate error samples with the
+            // error message.
+            debug('simple-oauth2 (method=%s)', method, err);
+            generator.res = err;
+          });
       }
 
-      const method = generator.connection.simple_oauth.method;
-      const simpleOauth = generator.connection.simple_oauth;
-
-      // special case for simple_oauth.salesforce
-      if (generator.connection.simple_oauth.salesforce) {
-        const credentials = {
-          clientId: simpleOauth.credentials.client.id,
-          clientSecret: simpleOauth.credentials.client.secret,
-          redirectUri: simpleOauth.credentials.client.redirectUri,
-        };
-
-        const org = nforce.createConnection(credentials);
-        return org.authenticate(simpleOauth.tokenConfig);
+      return null;
+    })
+    .then((token) => {
+      if (token) {
+        generator.OAuthToken = token;
       }
 
-      // otherwise when it's NOT simple_oauth.salesforce...
-      // eslint-disable-next-line global-require
-      const oauth2 = require('simple-oauth2').create(simpleOauth.credentials);
-      return oauth2[method].getToken(simpleOauth.tokenConfig);
-    }
-  })
-
-  .then((token) => {
-    if (token) generator.OAuthToken = token;
-
-    // Prepare auth
-    const conn = generator.generatorTemplate.connection;
-    if (generator.OAuthToken) {
-      // Expecting accessToken or access_token from remote source.
-      const accessToken = generator.OAuthToken.accessToken || generator.OAuthToken.access_token;
-      const simpleOauth = get(generator, 'connection.simple_oauth');
-      if (get(simpleOauth, 'tokenFormat')) {
-        set(conn, AUTH_HEADER,
-          simpleOauth.tokenFormat.replace('{accessToken}', accessToken));
-      } else if (accessToken) {
-        set(conn, AUTH_HEADER, accessToken);
+      // Prepare auth
+      const conn = generator.generatorTemplate.connection;
+      if (generator.OAuthToken) {
+        // Expecting accessToken or access_token from remote source.
+        const accessToken = generator.OAuthToken.accessToken ||
+          generator.OAuthToken.access_token;
+        const simpleOauth = get(generator, 'connection.simple_oauth');
+        if (get(simpleOauth, 'tokenFormat')) {
+          set(conn, AUTH_HEADER,
+            simpleOauth.tokenFormat.replace('{accessToken}', accessToken));
+        } else if (accessToken) {
+          set(conn, AUTH_HEADER, accessToken);
+        }
       }
-    }
 
-    // Prepare headers
-    generator.preparedHeaders = rce.prepareHeaders(conn.headers, context);
+      // Prepare headers
+      generator.preparedHeaders = rce.prepareHeaders(conn.headers, context);
 
-    // Prepare url
-    generator.preparedUrl = rce.prepareUrl(context, aspects, subjects, conn);
+      // Prepare url
+      generator.preparedUrl = rce.prepareUrl(context, aspects, subjects, conn);
 
-    debug('prepareRemoteRequest: preparedGenerator: %O', sanitize({
-      preparedUrl: generator.preparedUrl,
-      preparedHeaders: generator.preparedHeaders,
-      OAuthToken: generator.OAuthToken,
-      connection: generator.connection,
-    }, ['OAuthToken', 'Authorization', 'simple_oauth']));
-    return generator;
-  });
+      debug('prepareRemoteRequest: preparedGenerator: %O', sanitize({
+        preparedUrl: generator.preparedUrl,
+        preparedHeaders: generator.preparedHeaders,
+        OAuthToken: generator.OAuthToken,
+        connection: generator.connection,
+      }, ['OAuthToken', 'Authorization', 'simple_oauth']));
+      return generator;
+    });
 } // prepareRemoteRequest
 
 /**
  * Collect data. Prepare, then send the remote request.
  *
- * @param  {Object} generator   The generator object
+ * @param  {Object} generator - The generator object
  * @returns {Promise} - resolves to a generator object with a "res"
  *  attribute carrying the response from the remote data source
  */
-function doCollect(gen) {
-  debug('Entered "doCollect" for "%s"', gen.name);
-  return prepareRemoteRequest(gen)
-  .then((gen) => sendRemoteRequest(gen));
-}
+function doCollect(generator) {
+  debug('Entered "doCollect" for "%s"', generator.name);
+  return prepareRemoteRequest(generator)
+    .then(sendRemoteRequest);
+} // doCollect
 
 /**
  * Retrieves the list of subjects to collect data for, sets the array of
@@ -237,7 +249,7 @@ function doCollect(gen) {
 function collectBulk(generator) {
   debug('Entered "collectBulk" for "%s"', generator.name);
   return attachSubjectsToGenerator(generator)
-  .then((g) => doCollect(g));
+    .then(doCollect);
 } // collectBulk
 
 /**
@@ -252,12 +264,13 @@ function collectBulk(generator) {
 function collectBySubject(generator) {
   debug('Entered "collectBySubject" for "%s"', generator.name);
   return attachSubjectsToGenerator(generator)
-  .then((generator) => bluebird.map(generator.subjects, (subject) => {
-    // need to clone generator because we are doing async operation with generator data
-    const _g = JSON.parse(JSON.stringify(generator));
-    _g.subjects = [subject];
-    return doCollect(_g);
-  }));
+    .then((g) => bluebird.map(g.subjects, (subject) => {
+      // need to clone generator because we are doing async operation with
+      // generator data
+      const _g = JSON.parse(JSON.stringify(g));
+      _g.subjects = [subject];
+      return doCollect(_g);
+    }));
 } // collectBySubject
 
 module.exports = {

--- a/src/remoteCollection/collect.js
+++ b/src/remoteCollection/collect.js
@@ -135,7 +135,13 @@ function sendRemoteRequest(generator) {
         } // shouldRequestNewToken
 
         debug('sendRemoteRequest returned error %O', err);
-        generator.res = err;
+        if (get(generator, 'connection.simple_oauth')) {
+          const method = generator.connection.simple_oauth.method;
+          generator.res =
+            new Error(`simple-oauth2 (method=${method}): ${err.message}`);
+        } else {
+          generator.res = err;
+        }
       } else if (res) {
         debug('sendRemoteRequest returned OK');
         generator.res = res;
@@ -190,7 +196,8 @@ function prepareRemoteRequest(generator) {
             // force handleCollectResponse to generate error samples with the
             // error message.
             debug('simple-oauth2 (method=%s)', method, err);
-            generator.res = err;
+            generator.res =
+              new Error(`simple-oauth2 (method=${method}): ${err.message}`);
           });
       }
 

--- a/src/remoteCollection/handleCollectResponse.js
+++ b/src/remoteCollection/handleCollectResponse.js
@@ -18,14 +18,16 @@ const commonUtils = require('../utils/commonUtils');
 const RefocusCollectorEval = require('@salesforce/refocus-collector-eval');
 const httpUtils = require('../utils/httpUtils');
 const configModule = require('../config/config');
+const ZERO = 0;
 
 /**
  * Validates the response from the collect function. Confirms that it is an
  * object and has "res" and "name" attributes.
  *
- * @param  {Object} collectResponse - Response from the "collect" function,
- *  i.e. the generator object along with the "res" attribute which maps to the
- *  response from the remote data source.
+ * @param  {Object} cr - The collect response, i.e. the response from the
+ *  "collect" function, which is expected to be the generator object along with
+ *  the "res" attribute which maps to the response from the remote data source.
+ * @param  {Object} resSchema - The response schema
  * @throws {ValidationError} If the argument is not an object or is missing
  *  "res" or "name" attributes.
  */
@@ -89,9 +91,10 @@ function validateCollectResponse(cr, resSchema) {
  * Prepare arguments to be passed to the transform function.
  *
  * @param  {Object} generator - Generator object
- * @throws {TransformError} - if transform function does not return an array
- *  of zero or more samples
- * @throws {ValidationError} - if any of the above mentioned check fails
+ * @throws {Error} - TransformError if transform function does not return an
+ *  array of zero or more samples
+ * @throws {Error} - ValidationError if any of the validation checks fail
+ * @returns {Object} the transform args
  */
 function prepareTransformArgs(generator) {
   const args = {
@@ -102,70 +105,11 @@ function prepareTransformArgs(generator) {
   if (commonUtils.isBulk(generator)) {
     args.subjects = generator.subjects;
   } else {
-    args.subject = generator.subjects[0]; // FIXME once bulk is working
+    args.subject = generator.subjects[ZERO];
   }
 
   return args;
 } // prepareTransformArgs
-
-/**
- * Handles the responses from the remote data sources by calling the transform
- * function for each, then sending the samples from all responses to Refocus.
- *
- * @param  {Object} collectResArray - Array of responses from the "collect"
- * function: each element is the generator object along with the "res"
- * attribute which maps to the response from the remote data source
- * @returns {Promise} - resolves to the response from the bulkUpsert request
- * @throws {ValidationError} if thrown by validateCollectResponse
- */
-function handleCollectResponseBySubject(collectResArray) {
-  return Promise.map(collectResArray, (res) => generateSamples(res))
-    .then((samplesBySubject) =>
-      samplesBySubject.reduce((x, y) => [...x, ...y])
-    )
-    .then((samples) =>
-      sendSamples(collectResArray[0], samples)
-    );
-} // handleCollectResponseBySubject
-
-/**
- * Handles the response from the remote data source by calling the transform
- * function, then sending the samples from that response to Refocus.
- *
- * @param  {Object} collectRes - Response from the "collect" function: the
- * generator object along with the "res" attribute which maps to the response
- * from the remote data source
- * @returns {Promise} - resolves to the response from the bulkUpsert request
- * @throws {ValidationError} if thrown by validateCollectResponse
- */
-function handleCollectResponseBulk(collectRes) {
-  debug('handleCollectResponse status %s, body %O', collectRes.res.status,
-    collectRes.res.body);
-  const samples = generateSamples(collectRes);
-  return sendSamples(collectRes, samples);
-} // handleCollectResponse
-
-/**
- * Send samples to Refocus
- *
- * @param  {Object} collectRes - The generator object along with the "res"
- * attribute which maps to the response from the remote data source
- * @returns Promise - resolves to the response from the bulkUpsert request
- * @throws {ValidationError} if thrown by validateCollectResponse
- */
-function sendSamples(gen, samples) {
-  // Validate each of the samples.
-  samples.forEach(commonUtils.validateSample);
-  logger.info({
-    activity: 'upsert:samples',
-    generator: gen.name,
-    numSamples: samples.length,
-  });
-  const cr = configModule.getConfig().refocus;
-  return httpUtils.doBulkUpsert(
-    cr.url, gen.token, gen.intervalSecs, cr.proxy, samples
-  );
-}
 
 /**
  * Use the transform function to generate samples.
@@ -204,6 +148,65 @@ function generateSamples(collectRes) {
     `${collectRes.res.statusCode}: ${collectRes.res.statusMessage}`;
   return errorSamples(collectRes, errorMessage);
 } // generateSamples
+
+/**
+ * Validate the samples then send to Refocus using bulk upsert.
+ *
+ * @param  {Object} gen - The generator object along with the "res"
+ *  attribute which maps to the response from the remote data source
+ * @param  {Array<Object>} samples - The array of samples to send
+ * @returns {Promise<Object>} - resolves to the response from the bulkUpsert
+ *  request
+ * @throws {ValidationError} if thrown by validateCollectResponse
+ */
+function sendSamples(gen, samples) {
+  samples.forEach(commonUtils.validateSample);
+  logger.info({
+    activity: 'upsert:samples',
+    generator: gen.name,
+    numSamples: samples.length,
+  });
+  const cr = configModule.getConfig().refocus;
+  return httpUtils.doBulkUpsert(cr.url, gen.token, gen.intervalSecs, cr.proxy,
+    samples);
+} // sendSamples
+
+/**
+ * Handles the responses from the remote data sources by calling the transform
+ * function for each, then sending the samples from all responses to Refocus.
+ *
+ * @param  {Object} collectResArray - Array of responses from the "collect"
+ * function: each element is the generator object along with the "res"
+ * attribute which maps to the response from the remote data source
+ * @returns {Promise} - resolves to the response from the bulkUpsert request
+ * @throws {ValidationError} if thrown by validateCollectResponse
+ */
+function handleCollectResponseBySubject(collectResArray) {
+  return Promise.map(collectResArray, (res) => generateSamples(res))
+    .then((samplesBySubject) =>
+      samplesBySubject.reduce((x, y) => [...x, ...y])
+    )
+    .then((samples) =>
+      sendSamples(collectResArray[ZERO], samples)
+    );
+} // handleCollectResponseBySubject
+
+/**
+ * Handles the response from the remote data source by calling the transform
+ * function, then sending the samples from that response to Refocus.
+ *
+ * @param  {Object} collectRes - Response from the "collect" function: the
+ * generator object along with the "res" attribute which maps to the response
+ * from the remote data source
+ * @returns {Promise} - resolves to the response from the bulkUpsert request
+ * @throws {ValidationError} if thrown by validateCollectResponse
+ */
+function handleCollectResponseBulk(collectRes) {
+  debug('handleCollectResponse status %s, body %O', collectRes.res.status,
+    collectRes.res.body);
+  const samples = generateSamples(collectRes);
+  return sendSamples(collectRes, samples);
+} // handleCollectResponse
 
 module.exports = {
   handleCollectResponseBulk,

--- a/test/remoteCollection/collect.js
+++ b/test/remoteCollection/collect.js
@@ -20,8 +20,8 @@ logger.configure({ level: 0 });
 require('superagent-proxy')(request);
 const configModule = require('../../src/config/config');
 
+/* eslint-disable no-magic-numbers */
 describe('test/remoteCollection/collect.js >', () => {
-
   before((done) => {
     configModule.clearConfig();
     configModule.initializeConfig();
@@ -177,7 +177,7 @@ describe('test/remoteCollection/collect.js >', () => {
             Authorization: 'abddr121345bb',
           },
           url: 'http://www.xyz.com/status',
-          simple_oauth: 'ownerPassword',
+          simple_oauth: 'ownerPassword', // eslint-disable-line camelcase
         },
         transform: {
           default: 'return [{ name: "Fremont|Delay", value: 10 }, ' +
@@ -186,7 +186,7 @@ describe('test/remoteCollection/collect.js >', () => {
       },
       subjects: [{ absolutePath: 'EastBay' }],
       connection: {
-        simple_oauth: {
+        simple_oauth: { // eslint-disable-line camelcase
           credentials: {
             client: {
               id: '11bogus',
@@ -231,28 +231,28 @@ describe('test/remoteCollection/collect.js >', () => {
         { 'Content-Type': 'application/json' });
 
     collect.doCollect(generator)
-    .then((collectRes) => {
-      expect(collectRes.res).to.not.equal(undefined);
-      expect(collectRes.res.status).to.equal(httpStatus.OK);
-      expect(collectRes.res.body).to.deep.equal(remoteData);
+      .then((collectRes) => {
+        expect(collectRes.res).to.not.equal(undefined);
+        expect(collectRes.res.status).to.equal(httpStatus.OK);
+        expect(collectRes.res.body).to.deep.equal(remoteData);
 
-      expect(collectRes.res.req.headers['user-agent'])
-        .to.contain('node-superagent');
+        expect(collectRes.res.req.headers['user-agent'])
+          .to.contain('node-superagent');
 
-      expect(collectRes.generatorTemplate).to.deep
-        .equal(generator.generatorTemplate);
-      expect(collectRes.context).to.deep.equal(generator.context);
-      expect(collectRes.subjects).to.deep.equal(generator.subjects);
-      expect(collectRes.res.request.header.Authorization)
-        .to.equal('Bearer eegduygsugfiusguguygyfkufyg');
-      expect(generator.connection.simple_oauth.tokenConfig.username)
-        .to.equal('testUser');
-      expect(generator.connection.simple_oauth.tokenConfig.password)
-        .to.equal('testPassword');
+        expect(collectRes.generatorTemplate).to.deep
+          .equal(generator.generatorTemplate);
+        expect(collectRes.context).to.deep.equal(generator.context);
+        expect(collectRes.subjects).to.deep.equal(generator.subjects);
+        expect(collectRes.res.request.header.Authorization)
+          .to.equal('Bearer eegduygsugfiusguguygyfkufyg');
+        expect(generator.connection.simple_oauth.tokenConfig.username)
+          .to.equal('testUser');
+        expect(generator.connection.simple_oauth.tokenConfig.password)
+          .to.equal('testPassword');
 
-      done();
-    })
-    .catch(done);
+        done();
+      })
+      .catch(done);
   });
 
   it('collecting data with masking details, connection undefined', (done) => {
@@ -427,8 +427,7 @@ describe('test/remoteCollection/collect.js >', () => {
       connection: {
         simple_oauth: { // eslint-disable-line camelcase
           credentials: {
-            client: {
-            },
+            client: {},
             auth: {
               tokenHost: 'https://xyztest.argusTest.com',
               tokenPath: '/argusws/v2/auth/login',
@@ -574,7 +573,7 @@ describe('test/remoteCollection/collect.js >', () => {
         expect(collectRes.res).to.not.equal(undefined);
         expect(collectRes.res.status).to
           .equal(httpStatus.SERVICE_UNAVAILABLE);
-        expect(collectRes.res.body.error.message)
+        expect(collectRes.res.response.body.error.message)
           .to.contain('Server is down');
         done();
       })


### PR DESCRIPTION
so that handleCollectResponse will generate error samples

The crux of the change is catching the error thrown by oauth2[method].getToken(simpleOauth.tokenConfig). The rest of the changes are minor cleanup.