### PR TITLE
Quick fix hourly timeouts 

### DIFF
--- a/src/remoteCollection/collect.js
+++ b/src/remoteCollection/collect.js
@@ -39,9 +39,7 @@ const genAuth = require('../config/generatorAuth.js');
 function shouldRequestNewToken(err, generator) {
   const unauthorized = err.status === constants.httpStatus.UNAUTHORIZED;
   const simpleOauth = get(generator, 'connection.simple_oauth');
-  const token = genAuth.getGeneratorAuth(
-    generator.name, 'OAuthToken');
-  return unauthorized && simpleOauth && token;
+  return unauthorized && simpleOauth;
 } // shouldRequestNewToken
 
 /**


### PR DESCRIPTION
quick fix - When token expires, all the generator clones created by repeater assume that they need to get new token in that repeater run. The last generator saves the newly fetched token and that is used for subsequent runs until the token expires again in an hour.

Tested manually